### PR TITLE
Add note about extension shortcut on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 https://addons.mozilla.org/en-US/firefox/addon/firefox-new-container-tab/
 
-Opening a new tab in a Firefox container is hell—you have to either hard press the new tab button or remember obscure, limited shortcuts. New Container Tab changes that: you use the shortcut <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Comma</kbd>, search for a container name, and press <kbd>Enter</kbd>. Furthermore, the container search box auto-suggests, so speed is guaranteed! You can also enable the option to 'auto-open' tabs once a match is found.
+Opening a new tab in a Firefox container is hell—you have to either hard press the new tab button or remember obscure, limited shortcuts. New Container Tab changes that: you use the shortcut (Windows) <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Comma</kbd> or (macOS) <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>Comma</kbd>, search for a container name, and press <kbd>Enter</kbd>. Furthermore, the container search box auto-suggests, so speed is guaranteed! You can also enable the option to 'auto-open' tabs once a match is found.
+
+**Note:** You can always change default shortcuts at <code>about:addons</code> > Settings (gear icon) > Manage Extension Shortcuts
 
 ## Usage Examples
 


### PR DESCRIPTION
Love this extension already after using for just one day!

I'm sorry for the really tiny nit but the default shortcut is different between Windows/Linux machines and wanted to add that to the README. No need to merge if you just want to keep the README simple. Likely that most people would figure out the keybinding difference.

Let me know if you'd like me to record a gif for my note about changing default shortcuts.

Thanks!